### PR TITLE
Fixed deprecation warnings on Rails 4

### DIFF
--- a/lib/transactionata.rb
+++ b/lib/transactionata.rb
@@ -28,8 +28,8 @@ module Transactionata
         original_load_fixtures
         self.class.test_data_block.call
         
-        if defined?(ActiveRecord::Fixtures) # Rails 3.1
-          ActiveRecord::Fixtures.reset_cache
+        if defined?(ActiveRecord::FixtureSet) # Rails 3.1
+          ActiveRecord::FixtureSet.reset_cache
         else
           Fixtures.reset_cache # Required to enforce purging tables for every test file
         end


### PR DESCRIPTION
Hey! Good news, your gem still works on Rails 4 with MiniTest::Unit. There was only one slight issue: a deprecation warning about ActiveRecord::Fixtures class being deprecated. They recommend using FixtureSet instead and it works fine.
