### PR TITLE
Allow fixtures to be used in tests with test_data blocks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Transactionata
 
-Transactional dynamic test data for rails
+Transactional dynamic test data for rails, forked for easy porting from existing machinist tests
 
 == Synopsis
 
@@ -15,6 +15,8 @@ not leverage this for your Factory-built test data as well? Transactionata allow
     test_data do
       Factory.create(:user, :login => 'colszowka')
       # super-complex, time consuming, web-service-hooked-up test data setup continues
+      # Awkward mix of fixture generating frameworks to demonstrate instance variable carrying
+      @alternate_user = User.make(:login => 'bob@loblaw.com')
     end
     
     should "destroy a User" do
@@ -23,10 +25,19 @@ not leverage this for your Factory-built test data as well? Transactionata allow
   
     should "have a User" do
       assert User.find_by_login('colszowka')
+      assert_equal 'bob@loblaw.com', @alternate_user.login
     end
     
     context "The User" do
       subject { @user ||= User.find_by_login!('colszowka') }
+      
+      should "not be a new record" do
+        assert !subject.new_record?
+      end
+    end
+    
+    context "The alternate User" do
+      subject { @alternate_user }
       
       should "not be a new record" do
         assert !subject.new_record?

--- a/README.rdoc
+++ b/README.rdoc
@@ -75,6 +75,7 @@ but they have to be in place so Rails' Fixture loading mechanism will purge the 
 
 Transactionata's test suite currently runs against Rails 2.3.10 and 3.0.4 on Ruby 1.9.2, 1.8.7 and REE. Since no black magic is
 involved, it should work on other platforms and versions as well.
+It should also work on Rails 4.0.0.
 
 
 == Copyright

--- a/README.rdoc
+++ b/README.rdoc
@@ -75,7 +75,7 @@ but they have to be in place so Rails' Fixture loading mechanism will purge the 
 
 Transactionata's test suite currently runs against Rails 2.3.10 and 3.0.4 on Ruby 1.9.2, 1.8.7 and REE. Since no black magic is
 involved, it should work on other platforms and versions as well.
-It should also work on Rails 4.0.0.
+It should also work on Rails 4.1.0. It will not work on Rails 4.0.0 because the load_fixtures method now takes a config argument.
 
 
 == Copyright

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,11 @@
 
 Transactional dynamic test data for rails, forked for easy porting from existing machinist tests
 
+== Reason for Fork
+
+The main reason was to be able to use fixtures in the code, as well as FactoryGirl.
+I forked from asee's fork, because that allows the FactoryGirl objects to be accessible from instance variables in the tests.
+
 == Synopsis
 
 Fixture replacements like Factory Girl are great, but when you have to set up complex test data

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ end
 task :test => :"test:prepare"
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.rdoc_files.include('README*')

--- a/lib/transactionata.rb
+++ b/lib/transactionata.rb
@@ -34,8 +34,10 @@ module Transactionata
         existing_klass_instance_vars = self.class.instance_variables
         self.class.test_data_block.call
         @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
-        
-        if defined?(ActiveRecord::Fixtures) # Rails 3.1
+
+        if defined?(ActiveRecord::FixtureSet) # Rails 4
+          ActiveRecord::FixtureSet.reset_cache
+        elsif defined?(ActiveRecord::Fixtures) # Rails 3.1
           ActiveRecord::Fixtures.reset_cache
         else
           Fixtures.reset_cache # Required to enforce purging tables for every test file

--- a/lib/transactionata.rb
+++ b/lib/transactionata.rb
@@ -12,21 +12,27 @@ module Transactionata
   #   test_data do
   #     Factory.create(:foobar)
   #     # etc...
+  #     
+  #     # or for Machinist
+  #     @person =  Person.make
   #   end
   #
-  # The foobar record will be available in all your tests and rolls back even if you
-  # modify it in your test cases thanks to transactions.
+  # The foobar and @person record will be available in all your tests and rolls back 
+  # even if you modify it in your test cases thanks to transactions.
   #
   def test_data(&blk)
     self.class_eval do
       class << self
         attr_accessor :test_data_block
       end
+      setup :load_test_data_vars
       
       alias_method :original_load_fixtures, :load_fixtures
       def load_fixtures
         original_load_fixtures
+        existing_klass_instance_vars = self.class.instance_variables
         self.class.test_data_block.call
+        @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
         
         if defined?(ActiveRecord::Fixtures) # Rails 3.1
           ActiveRecord::Fixtures.reset_cache
@@ -34,6 +40,13 @@ module Transactionata
           Fixtures.reset_cache # Required to enforce purging tables for every test file
         end
       end
+      
+      def load_test_data_vars
+        @@test_data_vars.each do |new_ivar| # Added block
+          self.instance_variable_set(new_ivar, self.class.instance_variable_get(new_ivar))
+        end
+      end
+      
     end
     self.test_data_block = blk
   end

--- a/lib/transactionata.rb
+++ b/lib/transactionata.rb
@@ -29,7 +29,8 @@ module Transactionata
       
       alias_method :original_load_fixtures, :load_fixtures
       def load_fixtures
-        original_load_fixtures
+        # We need to return the value of the original load_fixtures method, so that all the fixtures magic works
+        hash = original_load_fixtures
         existing_klass_instance_vars = self.class.instance_variables
         self.class.test_data_block.call
         @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
@@ -39,6 +40,7 @@ module Transactionata
         else
           Fixtures.reset_cache # Required to enforce purging tables for every test file
         end
+        hash
       end
       
       def load_test_data_vars

--- a/lib/transactionata.rb
+++ b/lib/transactionata.rb
@@ -28,23 +28,35 @@ module Transactionata
       setup :load_test_data_vars
       
       alias_method :original_load_fixtures, :load_fixtures
-      def load_fixtures
-        # We need to return the value of the original load_fixtures method, so that all the fixtures magic works
-        hash = original_load_fixtures
-        existing_klass_instance_vars = self.class.instance_variables
-        self.class.test_data_block.call
-        @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
+      if defined?(ActiveRecord::FixtureSet) # Rails 4.1 or better
+        def load_fixtures(config)
+          # We need to return the value of the original load_fixtures method, so that all the fixtures magic works
+          hash = original_load_fixtures(config)
+          existing_klass_instance_vars = self.class.instance_variables
+          self.class.test_data_block.call
+          @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
 
-        if defined?(ActiveRecord::FixtureSet) # Rails 4
           ActiveRecord::FixtureSet.reset_cache
-        elsif defined?(ActiveRecord::Fixtures) # Rails 3.1
-          ActiveRecord::Fixtures.reset_cache
-        else
-          Fixtures.reset_cache # Required to enforce purging tables for every test file
+          hash
         end
-        hash
+
+      else
+        def load_fixtures
+          # We need to return the value of the original load_fixtures method, so that all the fixtures magic works
+          hash = original_load_fixtures
+          existing_klass_instance_vars = self.class.instance_variables
+          self.class.test_data_block.call
+          @@test_data_vars = (self.class.instance_variables - existing_klass_instance_vars)
+
+          if defined?(ActiveRecord::Fixtures) # Rails 3.1
+            ActiveRecord::Fixtures.reset_cache
+          else
+            Fixtures.reset_cache # Required to enforce purging tables for every test file
+          end
+          hash
+        end
       end
-      
+
       def load_test_data_vars
         @@test_data_vars.each do |new_ivar| # Added block
           self.instance_variable_set(new_ivar, self.class.instance_variable_get(new_ivar))

--- a/lib/transactionata/version.rb
+++ b/lib/transactionata/version.rb
@@ -1,3 +1,3 @@
 module Transactionata
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/lib/transactionata/version.rb
+++ b/lib/transactionata/version.rb
@@ -1,3 +1,3 @@
 module Transactionata
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/transactionata/version.rb
+++ b/lib/transactionata/version.rb
@@ -1,3 +1,3 @@
 module Transactionata
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/test/rails3/Gemfile
+++ b/test/rails3/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rails', '3.0.4'
+gem 'rails', '3.2.14'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'

--- a/test/rails3/test/factories/posts_factory.rb
+++ b/test/rails3/test/factories/posts_factory.rb
@@ -1,4 +1,6 @@
-Factory.define :post do |p|
-  p.title "Another great post"
-  p.body  "Some text for another great post"
+FactoryGirl.define do
+  factory :post do
+    title "Another great post"
+    body  "Some text for another great post"
+  end
 end

--- a/test/rails3/test/factories/users_factory.rb
+++ b/test/rails3/test/factories/users_factory.rb
@@ -1,7 +1,9 @@
-Factory.define :user do |u|
-  u.name "Some User"
-  u.login { "user_1" }
-  u.email {|f| "#{f.login}@example.com" }
-  u.password "someweirdpassword"
-  u.password_confirmation "someweirdpassword"
+FactoryGirl.define do
+  factory :user do
+    name "Some User"
+    login { "user_1" }
+    email { "#{login}@example.com" }
+    password "someweirdpassword"
+    password_confirmation "someweirdpassword"
+  end
 end

--- a/test/rails3/test/functional/posts_controller_test.rb
+++ b/test/rails3/test/functional/posts_controller_test.rb
@@ -4,9 +4,9 @@ class PostsControllerTest < ActionController::TestCase
   test_data do
     puts "Loading test data in #{self}"
     15.times do
-      Factory.create(:post)
+      FactoryGirl.create(:post)
     end
-    Factory.create(:post, :title => "Foobar")
+    FactoryGirl.create(:post, :title => "Foobar")
   end
   
   setup do

--- a/test/rails3/test/functional/users_controller_test.rb
+++ b/test/rails3/test/functional/users_controller_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class UsersControllerTest < ActionController::TestCase
   test_data do
     puts "Loading test data in #{self}"    
-    Factory.create(:user, :login => 'colszowka')
+    FactoryGirl.create(:user, :login => 'colszowka')
     8.times do
-      Factory.create(:user)
+      FactoryGirl.create(:user)
     end
   end
   

--- a/test/rails3/test/integration/ui_test.rb
+++ b/test/rails3/test/integration/ui_test.rb
@@ -5,10 +5,10 @@ class UiTest < ActionDispatch::IntegrationTest
   
   test_data do
     puts "Loading test data in #{self}"
-    user = Factory.create(:user, :login => 'testuser')
+    user = FactoryGirl.create(:user, :login => 'testuser')
     
     5.times do
-      Factory.create(:post, :user => user)
+      FactoryGirl.create(:post, :user => user)
     end
   end
 

--- a/test/rails3/test/unit/post_test.rb
+++ b/test/rails3/test/unit/post_test.rb
@@ -4,9 +4,9 @@ class PostTest < ActiveSupport::TestCase
   test_data do
     puts "Loading test data in #{self}"
     10.times do 
-      Factory.create(:post)
+      FactoryGirl.create(:post)
     end
-    Factory.create(:post, :title => "Foobar")
+    FactoryGirl.create(:post, :title => "Foobar")
   end
 
   should belong_to(:user)
@@ -15,7 +15,14 @@ class PostTest < ActiveSupport::TestCase
   should "have 13 Posts existing" do
     assert_equal 13, Post.count
   end
-  
+
+  # This test ensures that existing fixtures work
+  should "be able to access fixtures" do
+    assert_nothing_raised do
+      posts(:one)
+    end
+  end
+
   should "delete 5 posts" do
     5.times { assert Post.last.delete }
   end

--- a/test/rails3/test/unit/user_test.rb
+++ b/test/rails3/test/unit/user_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
   test_data do
     puts "Loading test data in #{self}"
-    user = Factory.create(:user, :login => 'testuser')
+    user = FactoryGirl.create(:user, :login => 'testuser')
     
     5.times do
-      Factory.create(:post, :user => user)
+      FactoryGirl.create(:post, :user => user)
     end
   end
 
   should have_many(:posts)
 
   should "create properly from Factory" do
-    assert user = Factory.create(:user)
+    assert user = FactoryGirl.create(:user)
   end
   
   should "delete all" do


### PR DESCRIPTION
I found that there was a bug in the load_fixtures method, which was not returning the original load_fixtures result. This meant that fixtures were unavailable in test code with test_data blocks.

The other commits were mainly to get the rails3 test app tests to run.
